### PR TITLE
Minor fixes to Snippets and Syntax Highlighting

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -35,7 +35,6 @@
 		["package", "endpackage"],
 		["primitive", "endprimitive"],
 		["program", "endprogram"],
-		["property", "else"],
 		["property", "endproperty"],
 		["randcase", "endcase"],
 		["specify", "endspecify"],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
 			{
 				"language": "systemverilog",
 				"scopeName": "source.systemverilog",
-				"path": "./syntaxes/systemverilog.tmLanguage.json"
+				"path": "./syntaxes/systemverilog.tmLanguage.json",
+				"balancedBracketScopes": [ "*" ],
+				"unbalancedBracketScopes": [ "keyword.sva.systemverilog" ]
 			}
 		],
 		"languages": [

--- a/snippets/systemverilog.snippets.json
+++ b/snippets/systemverilog.snippets.json
@@ -571,23 +571,23 @@
 	"assert": {
 		"prefix": "assert",
 		"body": [
-			"${1:assert_name}: assert (${2:condition}) ${3:success_process}",
-			"  else ${4:error_process}"
+			"${1:assert_name}: assert (${2:condition}) ${3:success_process};",
+			"  else ${4:error_process};"
 		],
 		"description": "...: assert (...) ... else ..."
 	},
 	"assert property": {
 		"prefix": "assert property",
 		"body": [
-			"assert property (${1:condition}) ${2:success_process}",
-			"  else ${3:error_process}"
+			"assert property (${1:condition}) ${2:success_process};",
+			"  else ${3:error_process};"
 		],
 		"description": "assert property (...) ... else ..."
 	},
 	"property": {
 		"prefix": "property",
 		"body": [
-			"property ${1:property_name}",
+			"property ${1:property_name};",
 			"  ${2:preperty_condition}",
 			"endproperty"
 		],

--- a/snippets/systemverilog.snippets.json
+++ b/snippets/systemverilog.snippets.json
@@ -412,7 +412,7 @@
     "always_ff statement": {
         "prefix": "always_ff",
         "body": [
-            "always_ff @( ${1:clock} ) : ${2:statementName}",
+            "always_ff @( ${1:clock} )",
             "  $0"
         ],
         "description": "always_ff statement"
@@ -420,7 +420,7 @@
     "always_comb statement": {
         "prefix": "always_comb",
         "body": [
-            "always_comb : ${1:statementName}",
+            "always_comb",
             "  $0"
         ],
         "description": "always_comb statement"
@@ -428,7 +428,7 @@
     "always_latch statement": {
         "prefix": "always_latch",
         "body": [
-            "always_latch : ${1:statementName}",
+            "always_latch",
             "  $0"
         ],
         "description": "always_latch statement"

--- a/syntaxes/systemverilog.tmLanguage.json
+++ b/syntaxes/systemverilog.tmLanguage.json
@@ -831,7 +831,7 @@
 			"name": "meta.module.no_parameters.systemverilog"
 		},
 		"functions": {
-			"match": "[ \\t\\r\\n]*\\b(?!while|for|if|iff|else|case|casex|casez|property)([a-zA-Z_][a-zA-Z0-9_$]*)(?=[ \\t\\r\\n]*\\()",
+			"match": "[ \\t\\r\\n]*\\b(?!while|for|if|iff|else|case|casex|casez|property|assert)([a-zA-Z_][a-zA-Z0-9_$]*)(?=[ \\t\\r\\n]*\\()",
 			"name": "entity.name.function.systemverilog"
 		},
 		"all-types": {


### PR DESCRIPTION
- Assertion and always block snippets should now be valid immediately.
- Syntax highlighting now allows `property` to match without an `endproperty` when used in `assert property` for concurrent assertions.

I have been using the extension in this state for a couple of months, but if anyone notices any issues in the syntax highlighting I can try to fix them.